### PR TITLE
Feature - support hackerearth

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import json
 import uuid
 
+from bs4 import BeautifulSoup
+
 from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo


### PR DESCRIPTION
# Subject
implemented a function to return competitive contests from HackerEarth.

Upcoming contests url: https://www.hackerearth.com/challenges/competitive/


## Demonstration
Sample contests:
![image](https://github.com/user-attachments/assets/799dde83-0529-4d8a-aa87-63a1aa691f9d)

Sample output: 
```json
[
  {
    "id": "f8aca81f62e54579855054c2e4f2fb6c",
    "platform": "HackerEarth",
    "title": "Thales GenTech India Hackathon",
    "url": "https://www.hackerearth.com/challenges/competitive/thales-hacakthon-2024/",
    "start_time": "2024-09-20T11:30:00+00:00",
    "duration": 802740
  },
  {
    "id": "7d4d7d43906c41049f6c0eae1921bd5b",
    "platform": "HackerEarth",
    "title": "GE Vernova�s IN-Code Challenge",
    "url": "https://www.hackerearth.com/challenges/competitive/ge-hunt-round-1/",
    "start_time": "2024-09-22T03:30:00+00:00",
    "duration": 43200
  }
]
```

## Implementation

HackerEarth have not exposed API endpoints for details of contests, therefore I scrape above mentioned url using BS4 to retrieve list of upcoming contests. but the list lacks detail of end time, thus i use the event slug to make a HTTP request and retrieve the start and end times.