### PR TITLE
Feature - support AtCoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json


### PR DESCRIPTION
# Subject
implemented a function to return competitive contests from AtCoder.

Upcoming contests url: https://atcoder.jp/contests/


## Demonstration
Sample contests:
![image](https://github.com/user-attachments/assets/800ccbc2-7eda-4ee1-a02c-37bec503f6f0)

Sample output: 
```json
[
    {
        "id": "0ccb445eeb8b4816ad35bfdd8431ea71",
        "platform": "AtCoder",
        "title": "UNIQUE VISION Programming Contest 2024 Autumn (AtCoder Beginner Contest 372)",
        "url": "https://atcoder.jp/contests/abc372",
        "start_time": "2024-09-21T21:00:00+09:00",
        "duration": 6000
    },
    {
        "id": "b4efca3b8695459e8fc084616c3fc3d5",
        "platform": "AtCoder",
        "title": "AtCoder Regular Contest 184",
        "url": "https://atcoder.jp/contests/arc184",
        "start_time": "2024-09-22T21:00:00+09:00",
        "duration": 7200
    },
    ...
]
```

## Implementation

AtCoder have not exposed API endpoints for details of contests, therefore I scrape above mentioned url using BS4 to retrieve list of upcoming contests. 

resolves #2 